### PR TITLE
Add abstraction layer to ExecutionSpan

### DIFF
--- a/qiskit_ibm_runtime/execution_span.py
+++ b/qiskit_ibm_runtime/execution_span.py
@@ -33,6 +33,9 @@ class ExecutionSpan(abc.ABC):
     A pub is said to have dependence on an execution span if the corresponding execution includes
     data that forms any part of the pub's results.
 
+    Execution spans are equality checkable, and they implement a comparison operator based on
+    the tuple ``(start, stop)``, so can be sorted.
+
     Args:
         start: The start time of the span, in UTC.
         stop: The stop time of the span, in UTC.
@@ -43,8 +46,11 @@ class ExecutionSpan(abc.ABC):
         self._stop = stop
 
     @abc.abstractmethod
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         pass
+
+    def __lt__(self, other: ExecutionSpan) -> bool:
+        return (self.start, self.stop) < (other.start, other.stop)
 
     def __repr__(self):
         attrs = [
@@ -258,3 +264,18 @@ class ExecutionSpans:
             pub_idx: One or more pub indices to filter.
         """
         return ExecutionSpans(span.filter_by_pub(pub_idx) for span in self)
+
+    def sort(self, inplace: bool = True) -> "ExecutionSpans":
+        """Return the same execution spans, sorted.
+
+        Sorting is done by the :attr:`~.ExecutionSpan.start` timestamp of each execution span.
+
+        Args:
+            inplace: Whether to sort this instance in place, or return a copy.
+
+        Returns:
+            This instance if ``inplace``, a new instance otherwise, sorted.
+        """
+        obj = self if inplace else ExecutionSpans(self)
+        obj._spans.sort()
+        return obj

--- a/qiskit_ibm_runtime/execution_span.py
+++ b/qiskit_ibm_runtime/execution_span.py
@@ -12,45 +12,98 @@
 
 """Execution span classes."""
 
-from typing import Iterable, Union, overload, Dict, List, Iterator
+from __future__ import annotations
+
+import abc
 from datetime import datetime
-from dataclasses import dataclass
+import math
+from typing import overload, Iterable, Iterator
+
+import numpy as np
+import numpy.typing as npt
 
 
-@dataclass(frozen=True)
-class ExecutionSpan:
-    """Stores an execution time span for a subset of job data."""
+ShapeType = tuple[int, ...]
+"""A shape tuple representing some nd-array shape."""
 
-    start: datetime
-    """The start time of the span, in UTC."""
 
-    stop: datetime
-    """The stop time of the span, in UTC."""
+class ExecutionSpan(abc.ABC):
+    """Abstract parent for classes that store an execution time span for a subset of job data.
 
-    data_slices: Dict[int, slice]
-    r"""Which data have dependence on this execution span.
-    
-    This is a mapping from pub indices to data slices, where:
-    
-    * A pub index is its 0-indexed position inside of the primitive run call. 
-    * A data slice references one or more shots from data, indicated that the corresponding 
-      pub result data was measured within the time window reported by this execution span.
-      
-      In the case of a shaped pub, i.e. a pub where the circuit is parametric and multiple 
-      parameter sets are specified in some array, a data slice references the *flattened* pub
-      result data, where flattening is done in row-major order and the shot axis is last. So for 
-      instance, if 32 shots are drawn from a pub with shape ``(3,)``, then there are ``96`` 
-      total shots ordered as 32-32-32, and ``slice(20, 40)`` would reference shots 20 through 
-      39 inclusive.
+    A pub is said to have dependence on an execution span if the corresponding execution includes
+    data that forms any part of the pub's results.
+
+    Args:
+        start: The start time of the span, in UTC.
+        stop: The stop time of the span, in UTC.
     """
+
+    def __init__(self, start: datetime, stop: datetime):
+        self._start = start
+        self._stop = stop
+
+    @abc.abstractmethod
+    def __eq__(self, other):
+        pass
+
+    def __repr__(self):
+        attrs = [
+            f"start='{self.start:%Y-%m-%d %H:%M:%S}'",
+            f"stop='{self.stop:%Y-%m-%d %H:%M:%S}'",
+            f"size={self.size}",
+        ]
+        return f"{type(self).__name__}(<{', '.join(attrs)}>)"
 
     @property
     def duration(self) -> float:
         """The duration of this span, in seconds."""
         return (self.stop - self.start).total_seconds()
 
-    def contains_pub(self, pub_idx: Union[int, Iterable[int]]) -> bool:
-        """Returns whether the pub with the given index has data with dependence on this span.
+    @property
+    @abc.abstractmethod
+    def pub_idxs(self) -> list[int]:
+        """Which pubs, by index, have dependence on this execution span."""
+
+    @property
+    def start(self) -> datetime:
+        """The start time of the span, in UTC."""
+        return self._start
+
+    @property
+    def stop(self) -> datetime:
+        """The stop time of the span, in UTC."""
+        return self._stop
+
+    @property
+    def size(self) -> int:
+        """The total number of results with dependence on this execution span, across all pubs.
+
+        This attribute is equivalent to the sum of the elements of all present :meth:`mask`\\s.
+        For sampler results, it represents the total number of shots with dependence on this
+        execution span.
+
+        Combine this attribute with :meth:`filter_by_pub` to find the size of some particular pub:
+
+        .. code:: python
+
+            span.filter_by_pub(2).size
+
+        """
+        return sum(self.mask(pub_idx).sum() for pub_idx in self.pub_idxs)
+
+    @abc.abstractmethod
+    def mask(self, pub_idx: int) -> npt.NDArray[np.bool_]:
+        """Return an array-valued mask specifying which parts of a pub result depend on this span.
+
+        Args:
+            pub_idx: The index of the pub to return a mask for.
+
+        Returns:
+            An array with the same shape as the pub data.
+        """
+
+    def contains_pub(self, pub_idx: int | Iterable[int]) -> bool:
+        """Return whether the pub with the given index has data with dependence on this span.
 
         Args:
             pub_idx: One or more pub indices from the original primitive call.
@@ -59,13 +112,14 @@ class ExecutionSpan:
             Whether there is dependence on this span.
         """
         pub_idx = {pub_idx} if isinstance(pub_idx, int) else set(pub_idx)
-        return not pub_idx.isdisjoint(self.data_slices)
+        return not pub_idx.isdisjoint(self.pub_idxs)
 
-    def filter_by_pub(self, pub_idx: Union[int, Iterable[int]]) -> "ExecutionSpan":
-        """Return a new span whose slices are filtered to the provided indices.
+    @abc.abstractmethod
+    def filter_by_pub(self, pub_idx: int | Iterable[int]) -> "ExecutionSpan":
+        """Return a new span whose slices are filtered to the provided pub indices.
 
         For example, if this span contains slice information for pubs with indices 1, 3, 4 and
-        `[1,4]` is provided, then the span returned by this method will contain slice information
+        ``[1, 4]`` is provided, then the span returned by this method will contain slice information
         for only those two indices, but be identical otherwise.
 
         Args:
@@ -74,20 +128,77 @@ class ExecutionSpan:
         Returns:
             A new filtered span.
         """
+
+
+class SliceSpan(ExecutionSpan):
+    """An :class:`~.ExecutionSpan` for data stored in a sliceable format.
+
+    This type of execution span references pub result data by assuming that it is a sliceable
+    portion of the (row major) flattened data. Therefore, for each pub dependent on this span, the
+    constructor accepts a single :class:`slice` object, along with the corresponding shape of the
+    data to be sliced.
+
+    Args:
+        start: The start time of the span, in UTC.
+        stop: The stop time of the span, in UTC.
+        data_slices: A map from pub indices to pairs ``(shape_tuple, slice)``.
+    """
+
+    def __init__(
+        self, start: datetime, stop: datetime, data_slices: dict[int, tuple[ShapeType, slice]]
+    ):
+        super().__init__(start, stop)
+        self._data_slices = data_slices
+
+    def __eq__(self, other):
+        return isinstance(other, SliceSpan) and (
+            self.start == other.start
+            and self.stop == other.stop
+            and self._data_slices == other._data_slices
+        )
+
+    @property
+    def pub_idxs(self) -> list[int]:
+        return sorted(self._data_slices)
+
+    @property
+    def size(self) -> int:
+        size = 0
+        for shape, sl in self._data_slices.values():
+            size += len(range(math.prod(shape))[sl])
+        return size
+
+    def mask(self, pub_idx: int) -> npt.NDArray[np.bool_]:
+        shape, sl = self._data_slices[pub_idx]
+        mask = np.zeros(shape, dtype=np.bool_)
+        mask.ravel()[sl] = True
+        return mask
+
+    def filter_by_pub(self, pub_idx: int | Iterable[int]) -> "SliceSpan":
         pub_idx = {pub_idx} if isinstance(pub_idx, int) else set(pub_idx)
-        slices = {idx: sl for idx, sl in self.data_slices.items() if idx in pub_idx}
-        return ExecutionSpan(self.start, self.stop, slices)
+        slices = {idx: val for idx, val in self._data_slices.items() if idx in pub_idx}
+        return SliceSpan(self.start, self.stop, slices)
 
 
-class ExecutionSpanSet:
+class ExecutionSpans:
     """A collection of timings for pub results.
 
     This class is a list-like containing :class:`~.ExecutionSpan`\\s, where each execution span
-    represents a time window of data collection and points to the data that was collected
-    during that window.
+    represents a time window of data collection, and contains a reference to exactly which of the
+    data were collected during the window.
 
-    Because these windows sometimes contain pieces of concurrent classical processing, It is possible for
-    them to overlap.
+    .. code::python
+
+        spans = sampler_job.result().metadata["execution"]["execution_spans"]
+
+        for span in spans:
+            print(span)
+
+    It is possible for distinct time windows to overlap. This is not because a QPU was performing
+    multiple executions at once, but is instead an artifact of certain classical processing
+    that may happen concurrently with quantum execution. The guarantee being made is that the
+    referenced data definitely occurred in the reported execution span, but not necessarily that
+    the limits of the time window are as tight as possible.
     """
 
     def __init__(self, spans: Iterable[ExecutionSpan]):
@@ -100,30 +211,33 @@ class ExecutionSpanSet:
     def __getitem__(self, idxs: int) -> ExecutionSpan: ...
 
     @overload
-    def __getitem__(self, idxs: Union[slice, List[int]]) -> "ExecutionSpanSet": ...
+    def __getitem__(self, idxs: slice | list[int]) -> "ExecutionSpans": ...
 
-    def __getitem__(
-        self, idxs: Union[int, slice, List[int]]
-    ) -> Union[ExecutionSpan, "ExecutionSpanSet"]:
+    def __getitem__(self, idxs: int | slice | list[int]) -> ExecutionSpan | "ExecutionSpans":
         if isinstance(idxs, int):
             return self._spans[idxs]
         if isinstance(idxs, slice):
-            return ExecutionSpanSet(self._spans[idxs])
-        return ExecutionSpanSet([self._spans[idx] for idx in idxs])
+            return ExecutionSpans(self._spans[idxs])
+        return ExecutionSpans(self._spans[idx] for idx in idxs)
 
     def __iter__(self) -> Iterator[ExecutionSpan]:
         return iter(self._spans)
 
     def __repr__(self) -> str:
-        return f"ExecutionSpanSet({repr(self._spans)})"
+        return f"ExecutionSpans({repr(self._spans)})"
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, ExecutionSpanSet) and self._spans == other._spans
+        return isinstance(other, ExecutionSpans) and self._spans == other._spans
+
+    @property
+    def pub_idxs(self) -> list[int]:
+        """Which pubs, by index, have dependence on one or more execution spans present."""
+        return sorted({idx for span in self for idx in span.pub_idxs})
 
     @property
     def start(self) -> datetime:
         """The start time of the entire collection, in UTC."""
-        return min(span.start for span in self._spans)
+        return min(span.start for span in self)
 
     @property
     def stop(self) -> datetime:
@@ -135,10 +249,12 @@ class ExecutionSpanSet:
         """The total duration of this collection, in seconds."""
         return (self.stop - self.start).total_seconds()
 
-    def filter_by_pub(self, pub_idx: Union[int, Iterable[int]]) -> "ExecutionSpanSet":
-        """Returns an ExecutionSpanSet filtered by pub"""
-        return ExecutionSpanSet([span.filter_by_pub(pub_idx) for span in self])
+    def filter_by_pub(self, pub_idx: int | Iterable[int]) -> "ExecutionSpans":
+        """Return a new set of spans where each one has been filtered to the specified pubs.
 
-    def plot(self) -> None:
-        """Show a timing diagram"""
-        raise NotImplementedError
+        See also :meth:~.ExecutionSpan.filter_by_pub`.
+
+        Args:
+            pub_idx: One or more pub indices to filter.
+        """
+        return ExecutionSpans(span.filter_by_pub(pub_idx) for span in self)

--- a/qiskit_ibm_runtime/utils/validations.py
+++ b/qiskit_ibm_runtime/utils/validations.py
@@ -23,7 +23,7 @@ from qiskit.primitives.containers.sampler_pub import SamplerPub
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit_ibm_runtime.utils.utils import is_isa_circuit, are_circuits_dynamic
 from qiskit_ibm_runtime.exceptions import IBMInputValueError
-from qiskit_ibm_runtime.execution_span import ExecutionSpanSet
+from qiskit_ibm_runtime.execution_span import ExecutionSpans
 
 
 def validate_classical_registers(pubs: List[SamplerPub]) -> None:
@@ -145,7 +145,7 @@ def validate_exec_spans_in_result(result: PrimitiveResult) -> bool:
         "execution" not in result.metadata
         or not isinstance(result.metadata["execution"], dict)
         or "execution_spans" not in result.metadata["execution"]
-        or not isinstance(result.metadata["execution"]["execution_spans"], ExecutionSpanSet)
+        or not isinstance(result.metadata["execution"]["execution_spans"], ExecutionSpans)
     ):
         return False
 

--- a/test/unit/test_data_serialization.py
+++ b/test/unit/test_data_serialization.py
@@ -42,7 +42,7 @@ from qiskit.primitives.containers import (
 from qiskit_aer.noise import NoiseModel
 from qiskit_ibm_runtime.utils import RuntimeEncoder, RuntimeDecoder
 from qiskit_ibm_runtime.fake_provider import FakeNairobi
-from qiskit_ibm_runtime.execution_span import ExecutionSpan, ExecutionSpanSet
+from qiskit_ibm_runtime.execution_span import SliceSpan, ExecutionSpans
 
 from .mock.fake_runtime_client import CustomResultRuntimeJob
 from .mock.fake_runtime_service import FakeRuntimeService
@@ -416,15 +416,15 @@ class TestContainerSerialization(IBMTestCase):
 
         metadata = {
             "execution": {
-                "execution_spans": ExecutionSpanSet(
+                "execution_spans": ExecutionSpans(
                     [
-                        ExecutionSpan(
+                        SliceSpan(
                             datetime(2022, 1, 1),
                             datetime(2023, 1, 1),
-                            {1: slice(4, 9), 0: slice(5, 7)},
+                            {1: ((100,), slice(4, 9)), 0: ((2, 5), slice(5, 7))},
                         ),
-                        ExecutionSpan(
-                            datetime(2024, 8, 20), datetime(2024, 8, 21), {0: slice(2, 3)}
+                        SliceSpan(
+                            datetime(2024, 8, 20), datetime(2024, 8, 21), {0: ((14,), slice(2, 3))}
                         ),
                     ]
                 )

--- a/test/unit/test_execution_span.py
+++ b/test/unit/test_execution_span.py
@@ -13,7 +13,7 @@
 """Tests SliceSpan and ExecutionSpans classes."""
 
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import ddt
 
 import numpy as np
@@ -52,6 +52,17 @@ class TestSliceSpan(IBMTestCase):
         self.assertEqual(self.span1, SliceSpan(self.start1, self.stop1, self.slices1))
         self.assertNotEqual(self.span1, self.span2)
         self.assertNotEqual(self.span1, "aoeu")
+
+    def test_comparison(self):
+        """Test the comparison method."""
+        self.assertLess(self.span1, self.span2)
+
+        dt = timedelta(seconds=1)
+        span1_plus = SliceSpan(self.start1, self.stop1 + dt, self.slices1)
+        self.assertLess(self.span1, span1_plus)
+
+        span1_minus = SliceSpan(self.start1, self.stop1 - dt, self.slices1)
+        self.assertGreater(self.span1, span1_minus)
 
     def test_duration(self):
         """Test the duration property"""
@@ -170,3 +181,17 @@ class TestExecutionSpans(IBMTestCase):
         self.assertEqual(self.spans[0], self.span1)
         self.assertEqual(self.spans[1], self.span2)
         self.assertEqual(self.spans[1, 0], ExecutionSpans([self.span2, self.span1]))
+
+    def test_sort(self):
+        """Test the sort method."""
+        spans = ExecutionSpans([self.span2, self.span1])
+        self.assertLess(spans[1], spans[0])
+        inplace_sort = spans.sort()
+        self.assertIs(inplace_sort, spans)
+        self.assertLess(spans[0], spans[1])
+
+        spans = ExecutionSpans([self.span2, self.span1])
+        new_sort = spans.sort(inplace=False)
+        self.assertIsNot(inplace_sort, spans)
+        self.assertLess(spans[1], spans[0])
+        self.assertLess(new_sort[0], new_sort[1])


### PR DESCRIPTION
### Summary

This PR is a detailed suggestion to #1833.

### Details and comments

The main idea of this suggestion is to remove `data_slices` from the public API, everything else are the details to make it happen. The reason I suggest removing this attribute from the public API is become I have become increasingly concerned that it's format, while okay right now,  will be insufficient in the future. I don't want to introduce an API that we'll need to break.

In order to remove it, it needs to be replaced by something more generic, and in such a way that it's possible to extend it later. So I turned `ExecutionSpan` into an ABC most notably with the new abstract methods `mask` and `size`. The current format is now called `SliceSpan` whose data model (`_data_slices`) is hidden to avoid downstream coming to depend on it, and then getting surprised when we introduce a different child of `ExecutionSpan` with something else. Note that `data_slices` is now required to hold shape tuples otherwise it's impossible to implement the `mask` method.

I also renamed `ExecutionSpanSet` to `ExecutionSpans` for brevity, and also because it's not very related to a `set`; my fault for suggesting this name in the first place.

