### PR TITLE
Add `TwirledSliceSpanV2`

### DIFF
--- a/qiskit_ibm_runtime/execution_span/__init__.py
+++ b/qiskit_ibm_runtime/execution_span/__init__.py
@@ -43,4 +43,4 @@ from .double_slice_span import DoubleSliceSpan
 from .execution_span import ExecutionSpan, ShapeType
 from .execution_spans import ExecutionSpans
 from .slice_span import SliceSpan
-from .twirled_slice_span import TwirledSliceSpan
+from .twirled_slice_span import TwirledSliceSpan, TwirledSliceSpanV2

--- a/qiskit_ibm_runtime/execution_span/twirled_slice_span.py
+++ b/qiskit_ibm_runtime/execution_span/twirled_slice_span.py
@@ -39,40 +39,26 @@ class TwirledSliceSpan(ExecutionSpan):
     * ``shape_slice`` is a slice of an array of shape ``twirled_shape[:-1]``, flattened,
     * and ``shots_slice`` is a slice of ``twirled_shape[-1]``.
 
-    When ``data_slice_version`` equals 2, the data slice tuples are of the form
-    ``(twirled_shape, at_front, shape_slice, shots_slice, pub_shots)``, where
-
-    * ``pub_shots`` is the number of shots requested for the pub. It can be smaller than
-      ``num_randomizations`` times ``shots_per_randomizations``, and the last axis of
-      :meth:`.TwirledSliceSpan.mask` must be truncated, such that its length becomes
-      equal to ``pub_shots``.
-
     Args:
         start: The start time of the span, in UTC.
         stop: The stop time of the span, in UTC.
         data_slices: A map from pub indices to length-4 tuples described above.
-        data_slice_version: The format version of the data slice tuples.
     """
 
     def __init__(
         self,
         start: datetime,
         stop: datetime,
-        data_slices: Mapping[
-            int, tuple[ShapeType, bool, slice, slice] | tuple[ShapeType, bool, slice, slice, int]
-        ],
-        data_slice_version: int = 1,
+        data_slices: Mapping[int, tuple[ShapeType, bool, slice, slice]],
     ):
         super().__init__(start, stop)
         self._data_slices = data_slices
-        self._data_slice_version = data_slice_version
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, TwirledSliceSpan) and (
             self.start == other.start
             and self.stop == other.stop
             and self._data_slices == other._data_slices
-            and self._data_slice_version == other._data_slice_version
         )
 
     @property
@@ -102,13 +88,41 @@ class TwirledSliceSpan(ExecutionSpan):
             shape = shape[1:-1] + shape[:1] + shape[-1:]
 
         # merge twirling axis and shots axis before returning
-        mask = mask.reshape((*shape[:-2], math.prod(shape[-2:])))
-        if self._data_slice_version == 2:
-            mask = mask[..., : self._data_slices[pub_idx][4]]  # type: ignore
-
-        return mask
+        return mask.reshape((*shape[:-2], math.prod(shape[-2:])))
 
     def filter_by_pub(self, pub_idx: int | Iterable[int]) -> "TwirledSliceSpan":
         pub_idx = {pub_idx} if isinstance(pub_idx, int) else set(pub_idx)
         slices = {idx: val for idx, val in self._data_slices.items() if idx in pub_idx}
-        return TwirledSliceSpan(self.start, self.stop, slices, self._data_slice_version)
+        return type(self)(self.start, self.stop, slices)
+
+
+class TwirledSliceSpanV2(TwirledSliceSpan):
+    """An iteration of :class:`~.TwirledSliceSpan` that additionally stores the number of pub shots.
+
+    This type of execution span references pub result data that came from a twirled sampler
+    experiment which was executed by either prepending or appending an axis to parameter values
+    to account for twirling. Concretely, ``data_slices`` is a map from pub slices to tuples
+    ``(twirled_shape, at_front, shape_slice, shots_slice, pub_shots)``, where everything is as in
+    :class:`~.TwirledSliceSpan`, but additionally:
+
+    * ``pub_shots`` is the number of shots requested for the pub. It can be smaller than
+      ``num_randomizations`` times ``shots_per_randomizations``, and the last axis of
+      :meth:`.TwirledSliceSpan.mask` must be truncated, such that its length becomes
+      equal to ``pub_shots``.
+
+    Args:
+        start: The start time of the span, in UTC.
+        stop: The stop time of the span, in UTC.
+        data_slices: A map from pub indices to length-5 tuples described above.
+    """
+
+    def __init__(
+        self,
+        start: datetime,
+        stop: datetime,
+        data_slices: Mapping[int, tuple[ShapeType, bool, slice, slice, int]],
+    ):
+        super().__init__(start, stop, data_slices)
+
+    def mask(self, pub_idx: int) -> npt.NDArray[np.bool_]:
+        return super().mask(pub_idx)[..., : self._data_slices[pub_idx][4]]


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR modifies @yaelbh 's idea a bit by making the modified execution span a new type, rather than a version flag within the class.

It's fine if this idea isn't accepted, not too much time was invested, I just wanted to try it out and see if it results in something cleaner or not, Yael can be the judge.

### Details and comments

One quirk of this implementation is that it opportunistically changes the serialization name from ExecutionSpanCollection to ExecutionSpans. Not only is this cosmetic, fixing an old class change name from a long time ago, it also has a functional role that is equivalent to the idea in Yael's branch: whenever server-side is updated to emit the new types, anyone who is still on the old client will get a big dictionary instead of ExecutionSpans, rather than a decoder error.

